### PR TITLE
Abbrev

### DIFF
--- a/church/church.py
+++ b/church/church.py
@@ -31,6 +31,7 @@ __all__ = ['Address', 'Personal',
 
 
 class Church(object):
+
     """
     A lazy initialization of locale for all classes that have locales.
     """
@@ -98,6 +99,7 @@ class Church(object):
 
 
 class Address(object):
+
     """
     Class for generate fake address data.
     """
@@ -170,7 +172,7 @@ class Address(object):
         address = _format()
         return address
 
-    def state(self):
+    def state(self, abbrev=False):
         """
         Get a random states or subject of country.
 
@@ -178,8 +180,8 @@ class Address(object):
         :Example:
             Alabama (for locale `en`).
         """
-        state_name = choice(pull('states', self.lang))
-        return state_name.strip()
+        state_name, abbreviation = choice(pull('states', self.lang)).split(' | ')
+        return abbreviation.strip() if abbrev is True else state_name.strip()
 
     def postal_code(self):
         """
@@ -257,6 +259,7 @@ class Address(object):
 
 
 class Numbers(object):
+
     """
     Class for generating numbers.
     """
@@ -306,6 +309,7 @@ class Numbers(object):
 
 
 class Text(object):
+
     """
     Class for generate text data, i.e text, lorem ipsum and another.
     """
@@ -507,6 +511,7 @@ class Text(object):
 
 
 class Business(object):
+
     """
     Class for generating data for business.
     """
@@ -571,6 +576,7 @@ class Business(object):
 
 
 class Personal(object):
+
     """
     Class for generate personal data, i.e names, surnames, age and another.
     """
@@ -1135,6 +1141,7 @@ class Personal(object):
 
 
 class Datetime(object):
+
     """
     Class for generate the fake data that you can use for
     working with date and time.
@@ -1244,6 +1251,7 @@ class Datetime(object):
 
 
 class Network(object):
+
     """
     Class for generate data for working with network,
     i.e IPv4, IPv6 and another
@@ -1306,6 +1314,7 @@ class Network(object):
 
 
 class File(object):
+
     """
     Class for generate fake data for files.
      """
@@ -1336,6 +1345,7 @@ class File(object):
 
 
 class Science(object):
+
     """
     Class for getting facts science.
     """
@@ -1401,6 +1411,7 @@ class Science(object):
 
 
 class Development(object):
+
     """
     Class for getting fake data for Developers.
     """
@@ -1526,6 +1537,7 @@ class Development(object):
 
 
 class Food(object):
+
     """
     Class for Food, i.e fruits, vegetables, berries and other.
     """
@@ -1593,6 +1605,7 @@ class Food(object):
 
 
 class Hardware(object):
+
     """
     Class for generate data about hardware.
 

--- a/church/church.py
+++ b/church/church.py
@@ -175,12 +175,13 @@ class Address(object):
     def state(self, abbrev=False):
         """
         Get a random states or subject of country.
-
+        
+        :param abbrev: Return only the abbreviation of a state.
         :returns: State of current country.
         :Example:
             Alabama (for locale `en`).
         """
-        state_name, abbreviation = choice(pull('states', self.lang)).split(' | ')
+        state_name, abbreviation = choice(pull('states', self.lang)).split('|')
         return abbreviation.strip() if abbrev is True else state_name.strip()
 
     def postal_code(self):

--- a/church/data/en/states
+++ b/church/data/en/states
@@ -1,50 +1,50 @@
-Alabama
-Alaska
-Arizona
-Arkansas
-California
-Colorado
-Connecticut
-Delaware
-Florida
-Georgia
-Hawaii
-Idaho
-Illinois
-Indiana
-Iowa
-Kansas
-Kentucky
-Louisiana
-Maine
-Maryland
-Massachusetts
-Michigan
-Minnesota
-Mississippi
-Missouri
-Montana
-Nebraska
-Nevada
-New Hampshire
-New Jersey
-New Mexico
-New York
-North Carolina
-North Dakota
-Ohio
-Oklahoma
-Oregon
-Pennsylvania
-Rhode Island
-South Carolina
-South Dakota
-Tennessee
-Texas
-Utah
-Vermont
-Virginia
-Washington
-West Virginia
-Wisconsin
-Wyoming
+Alabama | AL
+Alaska | AK
+Arizona | AZ
+Arkansas | AR
+California | CA
+Colorado | CO
+Connecticut | CT
+Delaware | DE
+Florida | FL
+Georgia | GA
+Hawaii | HI
+Idaho | ID
+Illinois | IL
+Indiana | IN
+Iowa | IA
+Kansas | KS
+Kentucky | KY
+Louisiana | LA
+Maine | ME
+Maryland | MD
+Massachusetts | MA
+Michigan | MI
+Minnesota | MN
+Mississippi | MS
+Missouri | MO
+Montana | MT
+Nebraska | NE
+Nevada | NV
+New Hampshire | NH
+New Jersey | NJ
+New Mexico | NM
+New York | NY
+North Carolina | NC
+North Dakota | ND
+Ohio | OH
+Oklahoma | OK
+Oregon | OR
+Pennsylvania | PA
+Rhode Island | RI
+South Carolina | SC
+South Dakota | SD
+Tennessee | TN
+Texas | TX
+Utah | UT
+Vermont | VT
+Virginia | VA
+Washington | WA
+West Virginia | WV
+Wisconsin | WI
+Wyoming | WY

--- a/tests/test_data/test_address.py
+++ b/tests/test_data/test_address.py
@@ -35,12 +35,11 @@ class AddressTestCase(TestCase):
         self.assertTrue(len(result) > 6)
 
     def test_state(self):
-        result = self.address.state()
+        result = self.address.state() + '\n'
         self.assertTrue(len(result) > 3)
 
-    def test_state_abbrev(self):
-        result = self.address.state(abbrev=True)
-        self.assertTrue(len(result) == 2)
+        result2 = self.address.state(abbrev=True) + '\n'
+        self.assertTrue(len(result2) == 3)
 
     def test_postal_code(self):
         result = self.address.postal_code()

--- a/tests/test_data/test_address.py
+++ b/tests/test_data/test_address.py
@@ -36,8 +36,11 @@ class AddressTestCase(TestCase):
 
     def test_state(self):
         result = self.address.state()
-        parent_file = pull('states', self.address.lang)
-        self.assertIn(result + '\n', parent_file)
+        self.assertTrue(len(result) > 3)
+
+    def test_state_abbrev(self):
+        result = self.address.state(abbrev=True)
+        self.assertTrue(len(result) == 2)
 
     def test_postal_code(self):
         result = self.address.postal_code()


### PR DESCRIPTION
I have added a flag to state to select the abbreviation of a state rather than the full name as per Issue #38. It is tested and the flag defaults to False.